### PR TITLE
Add missense and inactivating mutation labels to transcript chart

### DIFF
--- a/gd3.js
+++ b/gd3.js
@@ -3091,9 +3091,20 @@
           }).call(dragSlider);
         }
         if (showLegend) {
-          var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth / 2, axisLegend = actualSVG.append("g");
-          axisLegend.append("g").attr("transform", "translate(" + effectiveWidth + ",0)").append("text").attr("transform", "translate(" + style.legendTextWidth / 2 + ",42)rotate(90)").style("font-size", 12).style("dominant-baseline", "central").html('<tspan dy="0" text-anchor="middle">Protein Sequence</tspan><tspan x="0" dy="15" text-anchor="middle">Changes</tspan>');
-          axisLegend.append("g").attr("transform", "translate(" + effectiveWidth + "," + (height / 2 + style.transcriptBarHeight + 20) + ")").append("text").attr("transform", "translate(0)rotate(90)").attr("text-anchor", "start").style("font-size", 12).text("Inactivating");
+          var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth + 5, axisLegend = actualSVG.append("g");
+          var topLegend = axisLegend.append("g").attr("transform", "translate(" + effectiveWidth + ",0)");
+          bottomLegend = axisLegend.append("g").attr("transform", "translate(" + effectiveWidth + "," + (height / 2 + style.transcriptBarHeight + 20) + ")");
+          var textStyle = {
+            "font-family": style.fontFamily,
+            "font-weight": "bold",
+            opacity: .5
+          };
+          topLegend.selectAll("text").data([ "Protein Seq", "Changes" ]).enter().append("text").attr("transform", "rotate(90)").attr("text-anchor", "middle").attr("x", style.height / 4).attr("y", function(d, i) {
+            return i * 15;
+          }).style(textStyle).text(function(d) {
+            return d;
+          });
+          bottomLegend.append("text").style(textStyle).attr("transform", "rotate(90)").attr("text-anchor", "middle").attr("x", style.height / 4).attr("y", 7.5).style(textStyle).text("Inactivating");
           renderLegend();
         }
         function renderLegend() {
@@ -3117,7 +3128,7 @@
           legend.append("path").attr("class", "symbol").attr("d", d3.svg.symbol().type(function(d, i) {
             return d3.svg.symbolTypes[data.mutationTypesToSymbols[d]];
           }).size(2 * style.legendSymbolHeight)).style("stroke", "#95A5A6").style("stroke-width", 2).style("fill", "#95A5A6");
-          legend.append("text").attr("dx", 7).attr("dy", 3).text(function(d) {
+          legend.append("text").attr("dx", 7).attr("dy", 3).style("font-family", style.fontFamily).text(function(d) {
             return d.replace(/_/g, " ");
           });
           svg.attr("height", legendGroup.node().getBBox().height);
@@ -3193,7 +3204,7 @@
       legendTextWidth: style.legendTextWidth || 28,
       margin: style.margin || {
         left: 5,
-        right: 5,
+        right: 15,
         top: 5,
         bottom: 0
       }

--- a/gd3.js
+++ b/gd3.js
@@ -2852,9 +2852,10 @@
         for (var i = 0; i < data.get("datasets").length; i++) {
           sampleTypeToColor[data.get("datasets")[i]] = d3color(i);
         }
-        var height = style.height, scrollbarWidth = showScrollers ? style.scollbarWidth : 0, width = style.width - scrollbarWidth - style.margin.left - style.margin.right;
+        var height = style.height, scrollbarWidth = showScrollers ? style.scollbarWidth : 0, legendTextWidth = showLegend ? style.legendTextWidth : 0, width = style.width - scrollbarWidth - legendTextWidth - style.margin.left - style.margin.right;
         var mutationResolution = Math.floor(width / style.symbolWidth);
-        var svg = d3.select(this).selectAll("svg").data([ data ]).enter().append("svg").attr("height", height).attr("width", width + scrollbarWidth + style.margin.left + style.margin.right);
+        var actualSVG = d3.select(this).selectAll("svg").data([ data ]).enter().append("svg").attr("height", height).attr("width", width + scrollbarWidth + legendTextWidth + style.margin.left + style.margin.right);
+        var svg = actualSVG.append("g");
         var start = 0, stop = data.get("length");
         var x = d3.scale.linear().domain([ start, stop ]).range([ 0, width ]);
         var xAxis = d3.svg.axis().scale(x).orient("bottom").ticks(style.numXTicks).tickSize(0).tickPadding(style.xTickPadding);
@@ -3089,7 +3090,12 @@
             "stroke-width": 1
           }).call(dragSlider);
         }
-        if (showLegend) renderLegend();
+        if (showLegend) {
+          var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth / 2;
+          svg.append("g").attr("transform", "translate(" + effectiveWidth + ",0)").append("text").attr("transform", "rotate(90)").attr("text-anchor", "start").style("font-size", 12).text("Missense");
+          svg.append("g").attr("transform", "translate(" + effectiveWidth + "," + (height / 2 + style.transcriptBarHeight + 20) + ")").append("text").attr("transform", "rotate(90)").attr("text-anchor", "start").style("font-size", 12).text("Inactivating");
+          renderLegend();
+        }
         function renderLegend() {
           var mutationTypes = data.types, numTypes = mutationTypes.length, numRows = Math.ceil(numTypes / 2);
           var svg = selection.append("div").selectAll(".gd3-transcript-legend-svg").data([ data ]).enter().append("svg").attr("class", "gd3-transcript-legend-svg").attr("font-size", 10).attr("width", width), legendGroup = svg.append("g");
@@ -3116,6 +3122,7 @@
           });
           svg.attr("height", legendGroup.node().getBBox().height);
         }
+        actualSVG.attr("height", svg.node().getBBox().height);
         var allMutations = mutationsG.selectAll("path").on("mouseover.dispatch-sample", function(d) {
           gd3.dispatch.sample({
             sample: d.sample,
@@ -3181,6 +3188,7 @@
       width: style.width || 500,
       xTickPadding: style.xTickPadding || 1.25,
       scollbarWidth: style.scrollbarWidth || 15,
+      legendTextWidth: style.legendTextWidth || 15,
       margin: style.margin || {
         left: 5,
         right: 5,

--- a/gd3.js
+++ b/gd3.js
@@ -3091,9 +3091,9 @@
           }).call(dragSlider);
         }
         if (showLegend) {
-          var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth / 2;
-          svg.append("g").attr("transform", "translate(" + effectiveWidth + ",0)").append("text").attr("transform", "rotate(90)").attr("text-anchor", "start").style("font-size", 12).text("Missense");
-          svg.append("g").attr("transform", "translate(" + effectiveWidth + "," + (height / 2 + style.transcriptBarHeight + 20) + ")").append("text").attr("transform", "rotate(90)").attr("text-anchor", "start").style("font-size", 12).text("Inactivating");
+          var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth / 2, axisLegend = actualSVG.append("g");
+          axisLegend.append("g").attr("transform", "translate(" + effectiveWidth + ",0)").append("text").attr("transform", "translate(" + style.legendTextWidth / 2 + ",42)rotate(90)").style("font-size", 12).style("dominant-baseline", "central").html('<tspan dy="0" text-anchor="middle">Protein Sequence</tspan><tspan x="0" dy="15" text-anchor="middle">Changes</tspan>');
+          axisLegend.append("g").attr("transform", "translate(" + effectiveWidth + "," + (height / 2 + style.transcriptBarHeight + 20) + ")").append("text").attr("transform", "translate(0)rotate(90)").attr("text-anchor", "start").style("font-size", 12).text("Inactivating");
           renderLegend();
         }
         function renderLegend() {
@@ -3122,7 +3122,9 @@
           });
           svg.attr("height", legendGroup.node().getBBox().height);
         }
-        actualSVG.attr("height", svg.node().getBBox().height);
+        if (showLegend) {
+          actualSVG.attr("height", axisLegend.node().getBBox().height);
+        }
         var allMutations = mutationsG.selectAll("path").on("mouseover.dispatch-sample", function(d) {
           gd3.dispatch.sample({
             sample: d.sample,
@@ -3180,7 +3182,7 @@
   function transcriptStyle(style) {
     return {
       fontFamily: '"HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif',
-      height: style.height || 200,
+      height: style.height || 250,
       numXTicks: style.numXTicks || 5,
       symbolWidth: style.symbolWidth || 20,
       transcriptBarHeight: style.transcriptBarHeight || 20,
@@ -3188,7 +3190,7 @@
       width: style.width || 500,
       xTickPadding: style.xTickPadding || 1.25,
       scollbarWidth: style.scrollbarWidth || 15,
-      legendTextWidth: style.legendTextWidth || 15,
+      legendTextWidth: style.legendTextWidth || 28,
       margin: style.margin || {
         left: 5,
         right: 5,

--- a/src/transcript/transcriptChart.js
+++ b/src/transcript/transcriptChart.js
@@ -484,23 +484,39 @@ function transcriptChart(style) {
       // Render the legend
       if (showLegend){
         // Add the missense/inactivating legend text
-        var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth/2,
+        var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth + 5,
             axisLegend = actualSVG.append('g');
-        axisLegend.append('g')
-          .attr('transform', 'translate(' + effectiveWidth + ',0)')
-            .append('text')
-            .attr('transform', 'translate(' + (style.legendTextWidth)/2 + ',42)rotate(90)')
-            .style('font-size', 12)
-            .style('dominant-baseline', 'central')
-            .html('<tspan dy="0" text-anchor="middle">Protein Sequence</tspan>
-                   <tspan x="0" dy="15" text-anchor="middle">Changes</tspan>')
 
-        axisLegend.append('g')
-          .attr('transform', 'translate(' + effectiveWidth + ',' + (height/2 + style.transcriptBarHeight + 20) + ')')
+        var topLegend = axisLegend.append('g')
+                .attr('transform', 'translate(' + effectiveWidth + ',0)')
+            bottomLegend = axisLegend.append('g')
+                .attr('transform', 'translate(' + effectiveWidth + ','
+                      + (height/2 + style.transcriptBarHeight + 20) + ')');
+
+        var textStyle = {
+           "font-family": style.fontFamily,
+           "font-weight": "bold",
+           opacity: .5
+         };
+
+        topLegend.selectAll('text')
+            .data(['Protein Seq', 'Changes'])
+            .enter()
             .append('text')
-            .attr('transform', 'translate(0)rotate(90)')
-            .attr('text-anchor', 'start')
-            .style('font-size', 12)
+                .attr('transform', 'rotate(90)')
+                .attr('text-anchor', 'middle')
+                .attr('x', style.height/4)
+                .attr('y', function(d,i) { return i*15; })
+                .style(textStyle)
+                .text(function(d) { return d; });
+
+        bottomLegend.append('text')
+            .style(textStyle)
+            .attr('transform', 'rotate(90)')
+            .attr('text-anchor', 'middle')
+            .attr('x', style.height/4)
+            .attr('y', 7.5)
+            .style(textStyle)
             .text('Inactivating');
 
         renderLegend();
@@ -566,6 +582,7 @@ function transcriptChart(style) {
         legend.append('text')
           .attr('dx', 7)
           .attr('dy', 3)
+          .style('font-family', style.fontFamily)
           .text(function(d) { return d.replace(/_/g, ' ')});
 
         svg.attr('height', legendGroup.node().getBBox().height);

--- a/src/transcript/transcriptChart.js
+++ b/src/transcript/transcriptChart.js
@@ -20,18 +20,20 @@ function transcriptChart(style) {
 
       var height = style.height,
           scrollbarWidth = showScrollers ? style.scollbarWidth : 0,
-          width = style.width - scrollbarWidth - style.margin.left - style.margin.right;
+          legendTextWidth = showLegend ? style.legendTextWidth : 0,
+          width = style.width - scrollbarWidth - legendTextWidth - style.margin.left - style.margin.right;
 
       // max number of mutations that can fit along the axis
       var mutationResolution = Math.floor(width / style.symbolWidth);
 
-      var svg = d3.select(this)
+      var actualSVG = d3.select(this)
           .selectAll('svg')
           .data([data])
           .enter()
             .append('svg')
                 .attr('height', height)
-                .attr('width', width + scrollbarWidth + style.margin.left + style.margin.right);
+                .attr('width', width + scrollbarWidth + legendTextWidth + style.margin.left + style.margin.right);
+      var svg = actualSVG.append('g');
 
       // x scale for the entire visualization based on transcript length
       var start = 0,
@@ -480,7 +482,28 @@ function transcriptChart(style) {
 
       /////////////////////////////////////////////////////////////////////////
       // Render the legend
-      if (showLegend) renderLegend();
+      if (showLegend){
+        // Add the missense/inactivating legend text
+        var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth/2;
+        svg.append('g')
+          .attr('transform', 'translate(' + effectiveWidth + ',0)')
+            .append('text')
+            .attr('transform', 'rotate(90)')
+            .attr('text-anchor', 'start')
+            .style('font-size', 12)
+            .text('Missense')
+
+        svg.append('g')
+          .attr('transform', 'translate(' + effectiveWidth + ',' + (height/2 + style.transcriptBarHeight + 20) + ')')
+            .append('text')
+            .attr('transform', 'rotate(90)')
+            .attr('text-anchor', 'start')
+            .style('font-size', 12)
+            .text('Inactivating');
+
+        renderLegend();
+      }
+
       function renderLegend() {
         var mutationTypes = data.types,
             numTypes = mutationTypes.length,
@@ -545,6 +568,9 @@ function transcriptChart(style) {
 
         svg.attr('height', legendGroup.node().getBBox().height);
       }
+
+      // Set the height to the true height
+      actualSVG.attr('height', svg.node().getBBox().height);
 
       /////////////////////////////////////////////////////////////////////////
       // Dispatch

--- a/src/transcript/transcriptChart.js
+++ b/src/transcript/transcriptChart.js
@@ -484,19 +484,21 @@ function transcriptChart(style) {
       // Render the legend
       if (showLegend){
         // Add the missense/inactivating legend text
-        var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth/2;
-        svg.append('g')
+        var effectiveWidth = width + scrollbarWidth + style.margin.left + style.symbolWidth/2,
+            axisLegend = actualSVG.append('g');
+        axisLegend.append('g')
           .attr('transform', 'translate(' + effectiveWidth + ',0)')
             .append('text')
-            .attr('transform', 'rotate(90)')
-            .attr('text-anchor', 'start')
+            .attr('transform', 'translate(' + (style.legendTextWidth)/2 + ',42)rotate(90)')
             .style('font-size', 12)
-            .text('Missense')
+            .style('dominant-baseline', 'central')
+            .html('<tspan dy="0" text-anchor="middle">Protein Sequence</tspan>
+                   <tspan x="0" dy="15" text-anchor="middle">Changes</tspan>')
 
-        svg.append('g')
+        axisLegend.append('g')
           .attr('transform', 'translate(' + effectiveWidth + ',' + (height/2 + style.transcriptBarHeight + 20) + ')')
             .append('text')
-            .attr('transform', 'rotate(90)')
+            .attr('transform', 'translate(0)rotate(90)')
             .attr('text-anchor', 'start')
             .style('font-size', 12)
             .text('Inactivating');
@@ -570,7 +572,9 @@ function transcriptChart(style) {
       }
 
       // Set the height to the true height
-      actualSVG.attr('height', svg.node().getBBox().height);
+      if (showLegend){
+        actualSVG.attr('height', axisLegend.node().getBBox().height);
+      }
 
       /////////////////////////////////////////////////////////////////////////
       // Dispatch

--- a/src/transcript/transcriptStyle.js
+++ b/src/transcript/transcriptStyle.js
@@ -1,7 +1,7 @@
 function transcriptStyle(style) {
   return {
     fontFamily: '"HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif',
-    height: style.height || 200,
+    height: style.height || 250,
     numXTicks: style.numXTicks || 5,
     symbolWidth: style.symbolWidth || 20,
     transcriptBarHeight: style.transcriptBarHeight || 20,
@@ -9,7 +9,7 @@ function transcriptStyle(style) {
     width: style.width || 500,
     xTickPadding: style.xTickPadding || 1.25,
     scollbarWidth: style.scrollbarWidth || 15,
-    legendTextWidth: style.legendTextWidth || 15,
+    legendTextWidth: style.legendTextWidth || 28,
     margin: style.margin || { left: 5, right: 5, top: 5, bottom: 0 }
   };
 }

--- a/src/transcript/transcriptStyle.js
+++ b/src/transcript/transcriptStyle.js
@@ -9,6 +9,7 @@ function transcriptStyle(style) {
     width: style.width || 500,
     xTickPadding: style.xTickPadding || 1.25,
     scollbarWidth: style.scrollbarWidth || 15,
+    legendTextWidth: style.legendTextWidth || 15,
     margin: style.margin || { left: 5, right: 5, top: 5, bottom: 0 }
   };
 }

--- a/src/transcript/transcriptStyle.js
+++ b/src/transcript/transcriptStyle.js
@@ -10,6 +10,6 @@ function transcriptStyle(style) {
     xTickPadding: style.xTickPadding || 1.25,
     scollbarWidth: style.scrollbarWidth || 15,
     legendTextWidth: style.legendTextWidth || 28,
-    margin: style.margin || { left: 5, right: 5, top: 5, bottom: 0 }
+    margin: style.margin || { left: 5, right: 15, top: 5, bottom: 0 }
   };
 }


### PR DESCRIPTION
* Add missense and inactivating text to label the top and bottom of the transcript chart, respectively.
* Change transcript chart to reset the height after everything is drawn. Question: resetting the height after everything is drawn still allows mutations out of the viewport? Why is that?

The CNA chart needs to be updated to add the respective "Amplifications" and "Deletions" labels, and to use a default height like the transcript chart.